### PR TITLE
allow extensions key for mj-node-page

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function parseOptions(_options) {
 }
 
 function optionsForPage(options) {
-    var accepted_keys = ['html', 'linebreaks', 'equationNumbers', 'singleDollars', 'renderer', 'addPreview',
+    var accepted_keys = ['html', 'linebreaks', 'equationNumbers', 'singleDollars', 'renderer', 'addPreview', 'extensions',
     'removeJax', 'ex', 'width', 'useFontCache', 'useGlobalCache', 'xmlns', 'inputs', 'dpi', 'speakText', 'speakRuleset', 'speakStyle', 'timeout'];
     return _.pick(options, accepted_keys);
 }


### PR DESCRIPTION
It's not super easy to use extensions with mathjax-node right now, but it can be done: https://github.com/mathjax/MathJax-node/issues/318#issuecomment-293890752. This makes it possible with gulp-mathjax-node.